### PR TITLE
add user per period query scripts

### DIFF
--- a/lib/count-users-by-year-improved.rb
+++ b/lib/count-users-by-year-improved.rb
@@ -1,0 +1,35 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+today = Date.today.prev_day
+lastyear = today - 365
+
+#  puts "Total Tickets: #{@client.users.count}"
+
+puts "Total Users 2012"
+puts @client.search(:query => "type:user created_at>2012-01-01 created_at<2013-01-01 role:end-user -name:Zendesk organization_id:none").count
+puts "Total Users 2013"
+puts @client.search(:query => "type:user created_at>2013-01-01 created_at<2014-01-01 role:end-user -name:Zendesk organization_id:none").count
+puts "Total Users 2014"
+puts @client.search(:query => "type:user created_at>2014-01-01 created_at<2015-01-01 role:end-user -name:Zendesk organization_id:none").count
+puts "Total Users 2015"
+puts @client.search(:query => "type:user created_at>2015-01-01 created_at<2016-01-01 role:end-user -name:Zendesk organization_id:none").count
+puts "Total Users 2016"
+puts @client.search(:query => "type:user created_at>2016-01-01 created_at<2017-01-01 role:end-user -name:Zendesk organization_id:none").count
+puts "Total Users 2017 Q1"
+puts @client.search(:query => "type:user created_at>2017-01-01 created_at<2017-04-01 role:end-user -name:Zendesk organization_id:none").count
+puts "Total Users 2017 Q2"
+puts @client.search(:query => "type:user created_at>2017-04-01 created_at<2017-07-01 role:end-user -name:Zendesk organization_id:none").count
+puts "Total Users 2017 Q3/4"
+puts @client.search(:query => "type:user created_at>2017-07-01 created_at<2018-01-01 role:end-user -name:Zendesk organization_id:none").count
+puts "Total Users 2018 to 23 Jun"
+puts @client.search(:query => "type:user created_at>2018-01-01 created_at<2018-06-23 role:end-user -name:Zendesk organization_id:none").count
+
+#  last_login_at:none

--- a/lib/get-user-numbers-2012.rb
+++ b/lib/get-user-numbers-2012.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2012
+#
+
+@y2012_users = []
+
+(1..140).each do |i|
+  @client.search(:query => "type:user created_at>2012-01-01 created_at<2013-01-01 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2012_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2012_users", "w") { |file| file.write(@y2012_users) }

--- a/lib/get-user-numbers-2013.rb
+++ b/lib/get-user-numbers-2013.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2013
+#
+
+@y2013_users = []
+
+(1..708).each do |i|
+  @client.search(:query => "type:user created_at>2013-01-01 created_at<2014-01-01 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2013_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2013_users", "w") { |file| file.write(@y2013_users) }

--- a/lib/get-user-numbers-2014.rb
+++ b/lib/get-user-numbers-2014.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2014
+#
+
+@y2014_users = []
+
+(1..663).each do |i|
+  @client.search(:query => "type:user created_at>2014-01-01 created_at<2015-01-01 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2014_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2014_users", "w") { |file| file.write(@y2014_users) }

--- a/lib/get-user-numbers-2015.rb
+++ b/lib/get-user-numbers-2015.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2015
+#
+
+@y2015_users = []
+
+(1..925).each do |i|
+  @client.search(:query => "type:user created_at>2015-01-01 created_at<2016-01-01 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2015_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2015_users", "w") { |file| file.write(@y2015_users) }

--- a/lib/get-user-numbers-2016.rb
+++ b/lib/get-user-numbers-2016.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2016
+#
+
+@y2016_users = []
+
+(1..887).each do |i|
+  @client.search(:query => "type:user created_at>2016-01-01 created_at<2017-01-01 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2016_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2016_users", "w") { |file| file.write(@y2016_users) }

--- a/lib/get-user-numbers-2017q1.rb
+++ b/lib/get-user-numbers-2017q1.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2017 Q1
+#
+
+@y2017q1_users = []
+
+(1..1083).each do |i|
+  @client.search(:query => "type:user created_at>2017-01-01 created_at<2017-04-01 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2017q1_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2017q1_users", "w") { |file| file.write(@y2017q1_users) }

--- a/lib/get-user-numbers-2017q2.rb
+++ b/lib/get-user-numbers-2017q2.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2017 Q2
+#
+
+@y2017q2_users = []
+
+(1..1500).each do |i|
+  @client.search(:query => "type:user created_at>2017-04-01 created_at<2017-07-01 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2017q2_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2017q2_users", "w") { |file| file.write(@y2017q2_users) }

--- a/lib/get-user-numbers-2017q34.rb
+++ b/lib/get-user-numbers-2017q34.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2017 Q3/4
+#
+
+@y2017q34_users = []
+
+(1..856).each do |i|
+  @client.search(:query => "type:user created_at>2017-07-01 created_at<2018-01-01 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2017q34_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2017q34_users", "w") { |file| file.write(@y2017q34_users) }

--- a/lib/get-user-numbers-2018.rb
+++ b/lib/get-user-numbers-2018.rb
@@ -1,0 +1,24 @@
+require 'zendesk_api'
+
+@client = ZendeskAPI::Client.new do |config|
+  config.url = ENV['ZENDESK_URL']
+  config.username = ENV['ZENDESK_USER_EMAIL']
+  config.password = ENV['ZENDESK_USER_PASSWORD']
+
+  config.retry = true
+end
+
+#
+# 2018
+#
+
+@y2018_users = []
+
+(1..1734).each do |i|
+  @client.search(:query => "type:user created_at>2018-01-01 created_at<2018-06-23 role:end-user -name:Zendesk organization_id:none").page(i).each do |user|
+    @y2018_users << user['id']
+    puts user['id']
+  end
+end
+
+File.open("data/y2018_users", "w") { |file| file.write(@y2018_users) }


### PR DESCRIPTION

What
These scripts query for a set of matching user IDs per period and pull the IDs to local files.

Why
We will use the IDs to query tickets and last login data to remove IDs active > 1 year ago for GDPR.