### PR TITLE
Fix filename in get and delete scripts

### DIFF
--- a/lib/get-latest-ticket-numbers.rb
+++ b/lib/get-latest-ticket-numbers.rb
@@ -28,11 +28,12 @@ ticket_count_for_year = @client.search(:query => "type:ticket group_id:20188163 
 number_of_pages = (ticket_count_for_year.to_f / 100).ceil + 1
 
 (1..number_of_pages).each do |i|
+  # We use updated_at>2018 because we have removed ALL tickets before this date previously.
   @client.search(:query => "type:ticket group_id:20188163 status:closed updated_at>2018-01-01 updated_at<#{lastyear}").page(i).each do |ticket|
     @latest_tickets << ticket['id']
   end
 end
 
-File.open("data/latest-tickets-to-purge-#{today}", "w") { |file| file.write(@latest_tickets) }
+File.open("data/latest-tickets-to-purge", "w") { |file| file.write(@latest_tickets) }
 
 exit

--- a/scripts/delete_latest_tickets.sh
+++ b/scripts/delete_latest_tickets.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+today=`date -I`
+source_file="data/latest-tickets-to-purge"
+echo "source: ${source_file}"
+
+
+if [ "${DRY_RUN+1}" ] ; then
+  for raw_id in `cat ${source_file}`
+		do
+			clean_id=`echo $raw_id | sed -e 's/\,//g' | sed -e 's/\]//g' | sed -e 's/\[//g'`
+			echo "*** DRY_RUN TICKET ID = $clean_id ***"
+			echo "curl $ZENDESK_URL/tickets/$clean_id -v -u $ZENDESK_USER_EMAIL:ZENDESK_USER_PASSWORD -X DELETE"
+		done
+
+else
+
+	for raw_id in `cat data/${source_file}`
+		do
+			clean_id=`echo $raw_id | sed -e 's/\,//g' | sed -e 's/\]//g' | sed -e 's/\[//g'`
+			echo "REALLY DELETE"
+			curl $ZENDESK_URL/tickets/$clean_id -v -u $ZENDESK_USER_EMAIL:$ZENDESK_USER_PASSWORD -X DELETE
+		done
+fi


### PR DESCRIPTION

What?
Removed data addition to filename.

Why?
Filename mismatch due to different date calculations between retrieve script and delete script.

