### PR TITLE
update the README file to reflect current methods and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ Install ruby and gems
 gem install bundler
 cd zendesk-scripts
 bundle install
-gem install rest-client
-gem install zendesk_api
-gem update
 ```
 
 
@@ -97,16 +94,7 @@ data/delete_tickets_2013.sh
 ```
 
 * Exit the 'screen' session but leave the script running
-```
- ctrl+a
- d
-```
 
-* To resume the session
-
-```
-screen -rd [sessionname]
-```
 
 
 ### User Processes


### PR DESCRIPTION
This PR will update the README to include the latest proven methods and scripts used to remove legacy tickets and user accounts from Zendesk.

Closes #16.