### PR TITLE
add a dockerfile to permit concourse testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.6.4-slim-stretch
+
+WORKDIR /usr/src/app
+
+# RUN apt-get install bash
+RUN apt-get update
+RUN apt-get -y install git
+
+RUN cd $WORKDIR
+RUN pwd
+
+RUN git clone https://github.com/alphagov/zendesk-scripts.git .
+
+# RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,10 @@ FROM ruby:2.6.4-slim-stretch
 
 WORKDIR /usr/src/app
 
-# RUN apt-get install bash
-RUN apt-get update
-RUN apt-get -y install git
+RUN apt-get update && \
+    apt-get -y install git && \
+    apt-get clean
 
 RUN cd $WORKDIR
-RUN pwd
 
 RUN git clone https://github.com/alphagov/zendesk-scripts.git .
-
-# RUN bundle install


### PR DESCRIPTION
Adding a simple dockerfile which permits us to test a concourse pipeline job in preparation for a fully automated solution.