### PR TITLE
Add some required dependancies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.6.4-slim-stretch
 WORKDIR /usr/src/app
 
 RUN apt-get update && \
-    apt-get -y install git && \
+    apt-get -y install make gcc g++ git && \
     apt-get clean
 
 RUN cd $WORKDIR


### PR DESCRIPTION
During testing we discovered the build was failing due to missing
some dependanices, due to a small image being initially selected.

Co-Authored-By: name <camille.descartes@digital.cabinet-office.gov.uk>
Co-Authored-By: name <stephen.ford@digital.cabinet-office.gov.uk>