### PR TITLE
add curl to Dockerfile because it's required by a bash script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.6.4-slim-stretch
 WORKDIR /usr/src/app
 
 RUN apt-get update && \
-    apt-get -y install make gcc g++ git && \
+    apt-get -y install make gcc g++ git curl && \
     apt-get clean
 
 RUN cd $WORKDIR


### PR DESCRIPTION
Found during testing of the bash script responsible for deleting the 'fetched' ticket IDs. Curl used to pass the DELETE command against the ticket_ID to the API.