### PR TITLE
add script to count the number of deletable tickets per group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+/data/
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/lib/count-tickets-per-group-to-csv.rb
+++ b/lib/count-tickets-per-group-to-csv.rb
@@ -1,0 +1,29 @@
+require 'date'
+require 'json'
+require 'zendesk_api'
+require_relative 'zendesk-setup.rb'
+
+tomorrow = Date.today.next_day
+lastyear = tomorrow - 365
+
+puts "Total Groups: #{@client.groups.count}"
+# Output csv column headings
+puts "Group ID,Group Name,Group Total Tickets,Group Deletable Tickets"
+
+File.open "data/groups.json" do |input_file|
+  groups = JSON.load input_file
+
+  # Main loop starts
+  groups.each do |url|
+
+    group_id = url["id"]
+    group_name = url["name"]
+
+    # Count total tickets per group
+    group_total_tickets = @client.search(:query => "type:ticket group_id:#{group_id}").count.to_i
+    # Count deletable tickets per group
+    group_deletable_tickets = @client.search(:query => "type:ticket group_id:#{group_id} organization_id:none status:closed updated_at>=2012-01-01 updated_at<=#{lastyear}").count.to_i
+    # gsub replaces , with - so that csv import is clean
+    puts "#{group_id},#{group_name.gsub(', ', '-')},#{group_total_tickets},#{group_deletable_tickets}"
+  end
+end


### PR DESCRIPTION
We need to size the job of removing unwanted tickets from all groups.

This script requires an input file data/groups.json which can be generated from a suitable REST client, e.g. postman using https://govuk.zendesk.com/api/v2/groups.json and suitable auth.