### PR TITLE
add python3, pip3 and awscli so we can talk to S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM ruby:2.6.4-slim-stretch
 WORKDIR /usr/src/app
 
 RUN apt-get update && \
-    apt-get -y install make gcc g++ git curl && \
-    apt-get clean
+    apt-get -y install build-essential git curl python3-pip && \
+    apt-get clean && \
+    pip3 install awscli
 
 RUN cd $WORKDIR
 


### PR DESCRIPTION

Required to permit transfer of log files to S3 bucket for longer term storage.

Solo.