### PR TITLE
add logfile backup to S3 to permit audits

### DIFF
--- a/ci/runGDPR.yml
+++ b/ci/runGDPR.yml
@@ -24,13 +24,14 @@ jobs:
         - |
           cd /usr/src/app
           bundle install
-          bundle exec ruby /usr/src/app/lib/get-latest-ticket-numbers.rb
-          scripts/delete_latest_tickets.sh
-          bundle exec ruby /usr/src/app/lib/get-latest-ticket-numbers.rb
+          bundle exec ruby /usr/src/app/lib/tickets-autom8-able.rb
+          aws s3 cp $ZENDESK_LOG_FILE s3://${S3_BUCKET_NAME}/
+
 
         path: /bin/bash
       params:
+        ZENDESK_LOG_FILE: "zendesk-GDPR-tickets.`date +%Y-%m-%d`"
         ZENDESK_URL: ((zendesk-url))
         ZENDESK_USER_EMAIL: ((zendesk-email))
-        ZENDESK_USER_PASSWORD: ((zendesk-password))
+        ZENDESK_TOKEN: ((zendesk-token))
     task: run


### PR DESCRIPTION

There is a possibility in the future that RE may be asked, when did we delete xxx ticket, or what did we do on xx-xx-xx date. These log files will be stored in S3 to enable these questions to be answered.

Co-authored-by: Aditya Pahuja <aditya.pahuja@digital.cabinet-office.gov.uk>"
