### PR TITLE
rearrange the logfile upload to S3

### DIFF
--- a/ci/runGDPR.yml
+++ b/ci/runGDPR.yml
@@ -24,13 +24,12 @@ jobs:
         - |
           cd /usr/src/app
           bundle install
+          export ZENDESK_LOG_FILE="zendesk-GDPR-tickets.`date +%Y-%m-%d`"
           bundle exec ruby /usr/src/app/lib/tickets-autom8-able.rb
           aws s3 cp $ZENDESK_LOG_FILE s3://${S3_BUCKET_NAME}/
-
-
         path: /bin/bash
       params:
-        ZENDESK_LOG_FILE: "zendesk-GDPR-tickets.`date +%Y-%m-%d`"
+        S3_BUCKET_NAME: ((readonly_private_bucket_name))
         ZENDESK_URL: ((zendesk-url))
         ZENDESK_USER_EMAIL: ((zendesk-email))
         ZENDESK_TOKEN: ((zendesk-token))


### PR DESCRIPTION

We tried to execute the upload log-file task inside the ruby but actually it belongs out here and is now execute post the ruby script running. This will also permit monitoring and alerting downstream.

Successful operation is visible at https://cd-staging.gds-reliability.engineering/teams/sandbox/pipelines/gdpr-run/jobs/delete-gdpr-tickets/builds/27