### PR TITLE
Add user account deletion script

### DIFF
--- a/lib/user-ids-autom8-able.rb
+++ b/lib/user-ids-autom8-able.rb
@@ -1,0 +1,81 @@
+require 'rest-client'
+require 'json'
+
+require_relative 'zendesk-setup.rb'
+
+lastyear = Date.today.next_day - 365
+source_user_file = "data/selected_user_ids_meeting_gdpr_params.json"
+# some date fields have the value 'null' but we need to compare dates, so
+FALSE_DATE = "2012-01-01"
+
+File.readlines(source_user_file).each do |line|
+  user = JSON.parse(line)
+
+  # Extract some fields
+  updated_at = user["updated_at"]
+  last_login_at = user["last_login_at"]
+  user_id = user["id"]
+  active = user["active"]
+
+  # is user account already soft deleted, if so, fast track to hard delete
+  if active != "true"
+    puts "user account #{user_id} is already soft deleted"
+    updated_at = FALSE_DATE
+    last_login_at = FALSE_DATE
+  else
+    # user account is NOT soft deleted, so test for null dates and set false date
+    if updated_at.nil?
+      updated_at = FALSE_DATE
+    end
+
+    if last_login_at.nil?
+      last_login_at = FALSE_DATE
+    end
+
+  end
+
+  # parse dates so we can do comparisons
+  updated = Date.parse(updated_at)
+  last_login = Date.parse(last_login_at)
+
+  # base URL for soft / hard delted user accounts
+  url = "#{ENV['ZENDESK_URL']}/deleted_users/"
+
+  if last_login <= lastyear
+    if updated <= lastyear
+      # Potential DELETION candidate - check tickets
+      count = @client.search!(:query => "type:ticket requester:#{user_id}").count
+      ticket_count = Integer count
+      puts "ticket_count: #{ticket_count}"
+
+      if ticket_count == 0
+        puts "Soft delete user_id: #{user_id}"
+        begin
+          @client.users.destroy!(:id => user_id)
+
+        rescue ZendeskAPI::Error::RecordInvalid => api_error
+          puts "Received error user #{user_id} already deleted, skipping over"
+          next
+
+        end
+
+        puts "Hard deleting user_id: #{user_id}"
+        begin
+          # api does not support hard delete yet, so hard delete like this...
+          full_url = "#{url}#{user_id}.json"
+          puts "full_url: #{full_url}"
+          RestClient::Request.execute(method: :delete, url: full_url, user: ENV['ZENDESK_USER_EMAIL']+'/token', password: ENV['ZENDESK_TOKEN'])
+
+        rescue RestClient::Exception => api_error
+          puts "Received error from ZenDesk API Skipping over user #{user_id} => #{api_error}"
+          puts api_error.backtrace
+          next
+
+        end
+
+      else
+        puts "user_id: #{user_id} has #{ticket_count} tickets, not deleting"
+      end
+    end
+  end
+end


### PR DESCRIPTION

GDS requires an automated method of keeping Zendesk within GDPR parameters.

This script retrieves selected user accounts, checks each one against a set of parameters and first soft deletes, then hard deletes user accounts which will fall outside of GDPR requirements within the next 24 hours.
Existing user accounts which are already soft deleted are hard deleted.