### PR TITLE
add an upload to S3 event post user account deletion

### DIFF
--- a/ci/runGDPR.yml
+++ b/ci/runGDPR.yml
@@ -27,6 +27,10 @@ jobs:
           export ZENDESK_LOG_FILE="zendesk-GDPR-tickets.`date +%Y-%m-%d`"
           bundle exec ruby /usr/src/app/lib/tickets-autom8-able.rb
           aws s3 cp $ZENDESK_LOG_FILE s3://${S3_BUCKET_NAME}/
+          export ZENDESK_LOG_FILE="zendesk-GDPR-users.`date +%Y-%m-%d`"
+          bundle exec ruby /usr/src/app/lib/user-ids-autom8-able.rb
+          aws s3 cp $ZENDESK_LOG_FILE s3://${S3_BUCKET_NAME}/
+
         path: /bin/bash
       params:
         S3_BUCKET_NAME: ((readonly_private_bucket_name))


### PR DESCRIPTION

We need to retain the log files in order to answer any future audit questions. This change adds an 'upload log file to S3' to the end of the user account deletion process.

Tested successfully on staging concourse this morning.