### PR TITLE
move bundle install from runtime to buildtime and add prod pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /usr/src/app
 RUN apt-get update && \
     apt-get -y install build-essential git curl python3-pip && \
     apt-get clean && \
-    pip3 install awscli \
-    bundle install
-
+    pip3 install awscli 
 
 RUN git clone https://github.com/alphagov/zendesk-scripts.git .
+
+RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /usr/src/app
 RUN apt-get update && \
     apt-get -y install build-essential git curl python3-pip && \
     apt-get clean && \
-    pip3 install awscli
+    pip3 install awscli \
+    bundle install
 
-RUN cd $WORKDIR
 
 RUN git clone https://github.com/alphagov/zendesk-scripts.git .

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,62 @@
+resources: 
+- name: zendesk-scripts
+  type: git
+  icon: github-circle
+  source: 
+    branch: master
+    uri: "https://github.com/alphagov/zendesk-scripts.git"
+
+- name: nightly
+  type: time
+  icon: alarm
+  source: 
+    location: Europe/London
+    start: "01:00 AM"
+    stop: "05:00 AM"
+
+- name: gdpr-tickets-repository
+  type: docker-image
+  source:
+    repository: ((readonly_private_ecr_repo_url))
+    tag: concourse-gdpr-tickets-latest
+
+jobs: 
+- name: build-zendesk-GDPR-cleaner
+  serial: true
+  plan: 
+  - get: zendesk-scripts
+    trigger: true
+  - put: gdpr-tickets-repository
+    params:
+      build: build-gdpr
+
+- name: delete-tickets-and-user-accounts
+  serial: true
+  plan: 
+  - get: nightly
+    trigger: true
+  - config: 
+      image_resource: 
+        source: 
+          repository: ((readonly_private_ecr_repo_url))
+          tag: concourse-gdpr-tickets-latest
+        type: docker-image
+      platform: linux
+      run: 
+        args: 
+        - -xce
+        - |
+          cd /usr/src/app
+          export ZENDESK_LOG_FILE=zendesk-GDPR-tickets.`date +%Y-%m-%d`
+          bundle exec ruby /usr/src/app/lib/tickets-autom8-able.rb
+          aws s3 cp $ZENDESK_LOG_FILE s3://${S3_BUCKET_NAME}/
+          export ZENDESK_LOG_FILE=zendesk-GDPR-users.`date +%Y-%m-%d`
+          bundle exec ruby /usr/src/app/lib/user-ids-autom8-able.rb
+          aws s3 cp $ZENDESK_LOG_FILE s3://${S3_BUCKET_NAME}/
+        path: /bin/bash
+      params: 
+        S3_BUCKET_NAME: ((readonly_private_bucket_name))
+        ZENDESK_URL: ((zendesk-url))
+        ZENDESK_USER_EMAIL: ((zendesk-email))
+        ZENDESK_TOKEN: ((zendesk-token))
+    task: run


### PR DESCRIPTION

The small change moves the bundle install from runtime to build time on Daniel's review recommendation.
The large change is to add a single pipeline to remove Zendesk tickets and user accounts which match a set of parameters agreed with GOV.UK support.