### PR TITLE
slightly refactor Dockerfile and add a param to the build job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,8 @@ FROM ruby:2.6.4-slim-stretch
 WORKDIR /usr/src/app
 
 RUN apt-get update && \
-    apt-get -y install build-essential git curl python3-pip && \
+    apt-get -y install vim build-essential git curl python3-pip && \
     apt-get clean && \
-    pip3 install awscli 
-
-RUN git clone https://github.com/alphagov/zendesk-scripts.git .
-
-RUN bundle install
+    pip3 install awscli && \
+    git clone https://github.com/alphagov/zendesk-scripts.git . && \
+    bundle install

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -29,6 +29,7 @@ jobs:
   - put: gdpr-tickets-repository
     params:
       build: build-gdpr
+      dockerfile: build-gdpr/Dockerfile
 
 - name: delete-tickets-and-user-accounts
   serial: true


### PR DESCRIPTION

Concourse complaining about missing Dockerfile even though it did exist. Fixed by adding dockerfile: param to job.
Took the opportunity to slightly refactor the Dockerfile.

Tested locally.

With @adityapahuja 