### PR TITLE
fix the docker build section of pipeline with correct build param

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -28,7 +28,7 @@ jobs:
     trigger: true
   - put: gdpr-repository
     params:
-      build: build-gdpr
+      build: zendesk-scripts
 
 - name: delete-tickets-and-user-accounts
   serial: true


### PR DESCRIPTION

'build' param was incorrectly set. Worked correctly in 2 pipeline solution.
Tested by pushing this manually to big concourse and running the job.

To Review: view successful build log available at https://cd.gds-reliability.engineering/teams/autom8/pipelines/zendesk-gdpr-cleaner/jobs/build-zendesk-GDPR-cleaner/builds/12

Solo.