### PR TITLE
add a cronitor 'ping' on successful execution

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -60,3 +60,24 @@ jobs:
         ZENDESK_USER_EMAIL: ((zendesk-email))
         ZENDESK_TOKEN: ((zendesk-token))
     task: run
+
+  - task: cronitor-zendesk-GDPR-cleaner
+    timeout: 1m
+    config:
+      platform: linux
+      params:
+        CRONITOR_LINK: https://cronitor.link/FempMQ/complete
+      image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/curl-ssl
+            tag: cd404e5f6e7b96082c586e80921189769131f593
+      run:
+        path: sh
+        args:
+          - -c
+          - |
+            set -ue
+            echo 'Curling cronitor'
+            curl --fail "$CRONITOR_LINK"
+            echo 'Curled cronitor successfully'


### PR DESCRIPTION

Adding a cronitor ping if the Zendesk GDPR cleaner exits cleanly.
Alerting from cronitor after missing one ping (24 hrs), only as an in-hours email to autom8 team.
@chrisfarms FYI
With @blairboy362.