### PR TITLE
skip attempts to delete "shared_agent" users

### DIFF
--- a/lib/user-ids-autom8-able.rb
+++ b/lib/user-ids-autom8-able.rb
@@ -66,6 +66,15 @@ File.open(log_file_name, "w") do |log_file|
     user_id = user["id"]
     active = user["active"]
 
+    # is the user a shared agent (connected to another zendesk account)
+    # then skip as we cannot delete them
+    if user["shared_agent"]
+      message = "user account #{user_id} cannot be deleted as it is marked as a 'shared_agent' from another zendesk account"
+      puts messsage
+      log_file.puts message
+      next
+    end
+
     # base URL for soft / hard delted user accounts
     url = "#{ENV['ZENDESK_URL']}/deleted_users/"
 


### PR DESCRIPTION
zendesk has the concept of "shared" users[1]. These are users who's
account is created/owned by zendesk account A, but are visible/active in
zendesk account B.

Aparently we have some of those :shrug:

Since they belong to a different account, it seems you can't actually
delete them and since this script is about GDPR compliance, and it is
intended to ensure that end-user account data is purged (not that
active agent account data is purged), it seems sensible to skip these
annomolies.

[1] https://support.zendesk.com/hc/en-us/articles/203661466-Sharing-tickets-with-other-Zendesk-Support-accounts