### PR TITLE
Get agents list

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ Notes
 bundle exec ruby lib/count-users-by-year-for-deletion.rb
 ```
 
+#### Create groups.json
+
+```
+curl $ZENDESK_URL/groups.json -v -u "$ZENDESK_USER_EMAIL/token:$ZENDESK_TOKEN" > data/groups.json
+```
+
+#### Retrieve Agents
+```
+bundle exec ruby lib/get-all-agents.rb > data/agents.json
+```
+
+#### Select and convert json to csv
+```
+jq -r '.name + "," + .role + "," + (.default_group_id|tostring) + "," + (.active|tostring)' agents.json > agents.csv
+```
+
+#### Merge Agent and Group Description
+```
+sh scripts/merge-agent-and-group-description.sh
+```
+
 
 ## Contributing
 

--- a/lib/get-all-agents.rb
+++ b/lib/get-all-agents.rb
@@ -1,0 +1,24 @@
+# Usage - call script with bundle exec ruby lib/get-all-agents.rb
+
+require 'zendesk_api'
+require 'rest-client'
+require 'json'
+
+require_relative 'zendesk-setup.rb'
+
+# Usage: bundle exec ruby lib/get-all-agents.rb > data/agents.json
+
+search_results = @client.search(:query => "type:user role:agent organization_id:21891972")
+
+# The Zendesk API has 100 items per page, so programatically
+# determine how many pages we have by rounding to the nearest 100.
+
+user_count =  search_results.count
+number_of_pages = (user_count.to_f / 100).ceil
+
+# Loop through users matching criteria and 2 stage delete (soft then hard)
+(1..number_of_pages).each do |i|
+  search_results.page(i).each do |user|
+    puts user.to_json
+  end
+end

--- a/scripts/merge-agent-and-group-description.sh
+++ b/scripts/merge-agent-and-group-description.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+agents_in="data/agents.csv"
+groups_in="data/groups.json"
+agents_and_groups="data/agents-and-groups.csv"
+mv ${agents_and_groups} ${agents_and_groups}.bak
+
+while IFS= read -r agent
+do
+  # echo "agent=${agent}"
+  group_id=`echo ${agent} | cut -d "," -f3`
+  # echo "group_id=${group_id}"
+  group_txt=`grep ${group_id} ${groups_in} | cut -d "," -f2`
+  # echo "group_txt=${group_txt}"
+  echo ${agent},${group_txt} >> ${agents_and_groups}
+  sort -t "," -k2  ${agents_and_groups} > ${agents_and_groups}.sorted
+
+done < ${agents_in}


### PR DESCRIPTION
**Why**
To satisfy a request from GOV.UK to query our Zendesk account via the API for agents and their default group membership. It is likely that this request will be repeated and so is worth coding.

**What**
1. Create a ruby script to retrieve a list of all users with role=agent.
2. Using data/groups.json and new bash script, add group description to agents.
3. Update README.md to show outline process.