### PR TITLE
add rescue block to catch NetworkErrors

### DIFF
--- a/lib/user-ids-autom8-able.rb
+++ b/lib/user-ids-autom8-able.rb
@@ -128,8 +128,6 @@ File.open(log_file_name, "w") do |log_file|
             raise
           end
 
-
-
           hard_delete(user_id, url, log_file)
 
         else

--- a/lib/user-ids-autom8-able.rb
+++ b/lib/user-ids-autom8-able.rb
@@ -120,7 +120,15 @@ File.open(log_file_name, "w") do |log_file|
             puts message
             log_file.puts message
             next
+
+          rescue ZendeskAPI::Error::NetworkError => api_error
+            message = "Received network error, check user #{user_id}, skipping over. Details: #{api_error.backtrace}"
+            puts message
+            log_file.puts message
+            raise
           end
+
+
 
           hard_delete(user_id, url, log_file)
 


### PR DESCRIPTION
**Why**
Existing pipeline suffered occasional failures with network errors causing further user account deletions to be missed.

**What**
Catching network errors and continuing makes the deletion script more resilient. Add a 'rescue' block to handle this error and continue execution.