### PR TITLE
add a specific script to pull the list of groups to text format file

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,24 @@ Notes
 bundle exec ruby lib/count-users-by-year-for-deletion.rb
 ```
 
-#### Create groups.json
+#### Create groups (json and text)
+
+json
 
 ```
 curl $ZENDESK_URL/groups.json -v -u "$ZENDESK_USER_EMAIL/token:$ZENDESK_TOKEN" > data/groups.json
+```
+
+text
+
+```
+bundle exec ruby lib/get-groups-list-to-file.rb
+```
+
+#### Create custom_roles.json
+
+```
+curl $ZENDESK_URL/custom_roles.json -v -u "$ZENDESK_USER_EMAIL/token:$ZENDESK_TOKEN" > data/custom_roles.json
 ```
 
 #### Retrieve Agents
@@ -208,7 +222,7 @@ bundle exec ruby lib/get-all-agents.rb > data/agents.json
 
 #### Select and convert json to csv
 ```
-jq -r '.name + "," + .role + "," + (.default_group_id|tostring) + "," + (.active|tostring)' agents.json > agents.csv
+jq -r '.name + "," + .role + "," + (.default_group_id|tostring) + "," + (.active|tostring) + "," + (.custom_role_id|tostring)' data/agents.json > data/agents.csv
 ```
 
 #### Merge Agent and Group Description

--- a/lib/get-groups-list-to-file.rb
+++ b/lib/get-groups-list-to-file.rb
@@ -6,7 +6,7 @@ require_relative 'zendesk-setup.rb'
 
 output_file = "data/groups.out"
 
-File.open("#{output_file}", "w") do |file|
+File.open(output_file, "w") do |file|
 
   groups_list = @client.groups
 

--- a/lib/get-groups-list-to-file.rb
+++ b/lib/get-groups-list-to-file.rb
@@ -1,0 +1,19 @@
+require 'date'
+require 'json'
+require 'zendesk_api'
+
+require_relative 'zendesk-setup.rb'
+
+output_file = "data/groups.out"
+
+File.open("#{output_file}", "w") do |file|
+
+  groups_list = @client.groups
+
+  groups_list.each do |group|
+    group_id = group.id
+    group_name = group.name
+
+    file.write("#{group_id},#{group_name}\n")
+  end
+end


### PR DESCRIPTION
**Why**
At the moment we rely on curl'ing this information. In the pipeline we have automated the pull of groups. Lookup of group_id to group.name requires a human readable groups file.

**What**
Simple ruby script to use the ruby client to query groups and write some fields to a file for use by 'merge-agent-and-group-description.sh'