### PR TITLE
add retrieval of agent custom roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,16 +195,10 @@ Notes
 bundle exec ruby lib/count-users-by-year-for-deletion.rb
 ```
 
-#### Create groups (json and text)
+#### Create groups.json
 
-json
 ```
 curl $ZENDESK_URL/groups.json -v -u "$ZENDESK_USER_EMAIL/token:$ZENDESK_TOKEN" > data/groups.json
-```
-
-text
-```
-bundle exec ruby lib/get-groups-list-to-file.rb
 ```
 
 #### Create custom_roles (json and text)

--- a/README.md
+++ b/README.md
@@ -195,10 +195,27 @@ Notes
 bundle exec ruby lib/count-users-by-year-for-deletion.rb
 ```
 
-#### Create groups.json
+#### Create groups (json and text)
 
+json
 ```
 curl $ZENDESK_URL/groups.json -v -u "$ZENDESK_USER_EMAIL/token:$ZENDESK_TOKEN" > data/groups.json
+```
+
+text
+```
+bundle exec ruby lib/get-groups-list-to-file.rb
+```
+
+#### Create custom_roles (json and text)
+
+json
+```
+curl $ZENDESK_URL/custom_roles.json -v -u "$ZENDESK_USER_EMAIL/token:$ZENDESK_TOKEN" > data/custom_roles.json
+```
+text
+```
+bundle exec ruby lib/get-custom-roles-list-to-file.rb
 ```
 
 #### Retrieve Agents

--- a/lib/get-custom-roles-list-to-file.rb
+++ b/lib/get-custom-roles-list-to-file.rb
@@ -6,7 +6,7 @@ require_relative 'zendesk-setup.rb'
 
 output_file = "data/custom-roles.out"
 
-File.open("#{output_file}", "w") do |file|
+File.open(output_file, "w") do |file|
 
   custom_roles_list = @client.custom_roles
 

--- a/lib/get-custom-roles-list-to-file.rb
+++ b/lib/get-custom-roles-list-to-file.rb
@@ -1,0 +1,20 @@
+require 'date'
+require 'json'
+require 'zendesk_api'
+
+require_relative 'zendesk-setup.rb'
+
+output_file = "data/custom-roles.out"
+
+File.open("#{output_file}", "w") do |file|
+
+  custom_roles_list = @client.custom_roles
+
+  custom_roles_list.each do |role|
+    role_id = role.id
+    role_name = role.name
+    role_desc = role.description
+
+    file.write("#{role_id},#{role_name},#{role_desc}\n")
+  end
+end


### PR DESCRIPTION
**Why**
We need to retrieve custom roles so that we can perform lookups against role.id

**What**
ruby script to retrieve agent custom roles and write to file. Preliminary, required by 'merge-agent-and-group-description.sh' when it is updated shortly.