### PR TITLE
set the schedule to an agreed 6hrly between start & finish hours.

### DIFF
--- a/ci/zendesk_de-duplicator.yml
+++ b/ci/zendesk_de-duplicator.yml
@@ -6,11 +6,13 @@ resources:
     branch: master
     uri: "https://github.com/alphagov/zendesk-scripts.git"
 
-- name: hourly
+- name: schedule
   type: time
   icon: alarm
   source:
-    interval: 1h
+    interval: 6h
+    start: 6:00 AM
+    stop: 8:00 PM
 
 - name: dedupe-repository
   type: docker-image
@@ -30,7 +32,7 @@ jobs:
 - name: dedupe-tickets
   serial: true
   plan:
-  - get: hourly
+  - get: schedule
     trigger: true
   - get: dedupe-repository
     trigger: true
@@ -47,6 +49,6 @@ jobs:
           bundle exec ruby /usr/src/app/lib/zendesk-ticket-deduplicator.rb
         path: /bin/bash
       params:
-        ZENDESK_URL: ((zendesk-url))
+        ZENDESK_URL: https://govuk.zendesk.com/api/v2
         ZENDESK_USER_EMAIL: ((zendesk-email))
         ZENDESK_TOKEN: ((zendesk-token))

--- a/lib/zendesk-ticket-deduplicator.rb
+++ b/lib/zendesk-ticket-deduplicator.rb
@@ -3,8 +3,8 @@ require_relative 'zendesk-setup.rb'
 require 'rest-client'
 require 'json'
 
-# Setup time window
-window_start_time = Time.now - 2 * 3600
+# Setup time window - schedule is 06, 12, 18, so need to look back 12h to handle 06 run.
+window_start_time = Time.now - 12 * 3600
 start_time = window_start_time.strftime('%Y-%m-%dT%H:%M:%S%z')
 
 # Change date to 2020-01-01


### PR DESCRIPTION
**What**
The script should query the past 12h of ticket creation date/time stamp. This permits the 6am execution to identify tickets from 6pm the previous day.

Pipeline scheduling modified and renamed to suit the new requirement.

**Why**
The change in schedule is at the request of and to suit Support Manager and team working practices. 6 hours gives the team time to react to the script's actions.

