### PR TITLE
separate the two Zendesk pipelines sharing this repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,11 @@ bundle exec ruby lib/zendesk-ticket-deduplicator.rb
 fly  -t cd-autom8 set-pipeline -p zendesk-deduplicator -c ci/zendesk_de-duplicator.yml
 ```
 
-##### Important Note
+##### Important Notes
 
-This pipeline should only run 6 hourly in order to mesh with the manual processes carried out by the support team. If updating the code, please pause the pipeline to ensure it does not run between the 6 hour windows.
+* This pipeline should only run 6 hourly in order to mesh with the manual processes carried out by the support team. If updating the code, please pause the pipeline before merging to ensure it does not run between the 6 hour windows.
+* Running outside of the schedule may cause tickets to be moved around unexpectedly during the hours people are working on them.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,15 @@ window_start_time = Time.now - 24 * 3600
 bundle exec ruby lib/zendesk-ticket-deduplicator.rb
 ```
 
+##### Deploy the pipeline
+
+```
+fly  -t cd-autom8 set-pipeline -p zendesk-deduplicator -c ci/zendesk_de-duplicator.yml
+```
+
+##### Important Note
+
+This pipeline should only run 6 hourly in order to mesh with the manual processes carried out by the support team. If updating the code, please pause the pipeline to ensure it does not run between the 6 hour windows.
 
 ## Contributing
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,7 +6,7 @@ resources:
     branch: master
     uri: "https://github.com/alphagov/zendesk-scripts.git"
     ignore_paths:
-    - /usr/src/app/lib/zendesk-ticket-deduplicator.rb
+    - lib/zendesk-ticket-deduplicator.rb
     - ci/zendesk_de-duplicator.yml
 
 - name: nightly

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -51,10 +51,10 @@ jobs:
         - |
           cd /usr/src/app
           export ZENDESK_LOG_FILE=zendesk-GDPR-tickets.`date +%Y-%m-%d`
-          bundle exec ruby /usr/src/app/lib/tickets-autom8-able.rb
+          bundle exec ruby lib/tickets-autom8-able.rb
           aws s3 cp $ZENDESK_LOG_FILE s3://${S3_BUCKET_NAME}/
           export ZENDESK_LOG_FILE=zendesk-GDPR-users.`date +%Y-%m-%d`
-          bundle exec ruby /usr/src/app/lib/user-ids-autom8-able.rb
+          bundle exec ruby lib/user-ids-autom8-able.rb
           aws s3 cp $ZENDESK_LOG_FILE s3://${S3_BUCKET_NAME}/
         path: /bin/bash
       params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -5,6 +5,9 @@ resources:
   source:
     branch: master
     uri: "https://github.com/alphagov/zendesk-scripts.git"
+    ignore_paths:
+    - /usr/src/app/lib/zendesk-ticket-deduplicator.rb
+    - ci/zendesk_de-duplicator.yml
 
 - name: nightly
   type: time

--- a/ci/zendesk_de-duplicator.yml
+++ b/ci/zendesk_de-duplicator.yml
@@ -6,7 +6,7 @@ resources:
     branch: master
     uri: "https://github.com/alphagov/zendesk-scripts.git"
     paths:
-    - /usr/src/app/lib/zendesk-ticket-deduplicator.rb
+    - lib/zendesk-ticket-deduplicator.rb
     - ci/zendesk_de-duplicator.yml
 
 - name: schedule

--- a/ci/zendesk_de-duplicator.yml
+++ b/ci/zendesk_de-duplicator.yml
@@ -5,6 +5,9 @@ resources:
   source:
     branch: master
     uri: "https://github.com/alphagov/zendesk-scripts.git"
+    paths:
+    - /usr/src/app/lib/zendesk-ticket-deduplicator.rb
+    - ci/zendesk_de-duplicator.yml
 
 - name: schedule
   type: time

--- a/ci/zendesk_de-duplicator.yml
+++ b/ci/zendesk_de-duplicator.yml
@@ -49,7 +49,7 @@ jobs:
         - -xce
         - |
           cd /usr/src/app
-          bundle exec ruby /usr/src/app/lib/zendesk-ticket-deduplicator.rb
+          bundle exec ruby lib/zendesk-ticket-deduplicator.rb
         path: /bin/bash
       params:
         ZENDESK_URL: https://govuk.zendesk.com/api/v2


### PR DESCRIPTION
Currently a merge to this repository will trigger both pipelines. That is undesirable for the deduplicator because there are manual followup activities carried out by the support team after it runs. These changes will separate the 2 tasks such that only a merge to the respective code will trigger the pipeline.

Updated README with explanation.