### PR TITLE
add error handling to cope with network ReadTimeout

### DIFF
--- a/lib/user-ids-autom8-able.rb
+++ b/lib/user-ids-autom8-able.rb
@@ -121,6 +121,12 @@ File.open(log_file_name, "w") do |log_file|
             log_file.puts message
             next
 
+          rescue ZendeskAPI::Error::ReadTimeout => api_error
+            message = "Received network error deleting user #{user_id}, skipping over. Details: #{api_error.backtrace}"
+            puts message
+            log_file.puts message
+            next
+
           rescue ZendeskAPI::Error::NetworkError => api_error
             message = "Received network error, check user #{user_id}, skipping over. Details: #{api_error.backtrace}"
             puts message


### PR DESCRIPTION
# Why
A recent network failure caused the application to fail. We should be able to detect this error and allow the app to continue with the next ID. The failed ID would be handled the following night automatically.

# What
Add error handling for Net::ReadTimeout

# Notes
This pipeline will automatically update following a successful merge.
