### PR TITLE
add a reference to the Zendesk account and password handling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,81 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-10-12T09:44:49Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "a887b5b1a5e6d27a42e72127a757d10b44bec7ce",
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "8707d232b3905eb77620c228f459fe007e315f17",
+        "is_verified": false,
+        "line_number": 109,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Follow the instructions to hijack the container and add 'per pipeline' entries f
 * ZENDESK_TOKEN
 * ZENDESK_USER_PASSWORD (Only required if token not available)
 
+The Zendesk account email address and password are stored in [re-secrets](https://github.com/alphagov/re-secrets/) because together they have hard deletion capability in many ticket / user groups.
 
 
 #### Deploy the pipeline


### PR DESCRIPTION
# Why
We have catered for the sensitive Zendesk account password and email address in a different repo. Let's refer to that here so folks know where to find those items.

# What
Add a reference to the README.md to the repo where the sensitive stuff is stored.