### PR TITLE
BAU: Switch from Dockerhub to GHCR for the curl container

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -72,8 +72,8 @@ jobs:
       image_resource:
           type: docker-image
           source:
-            repository: governmentpaas/curl-ssl
-            tag: cd404e5f6e7b96082c586e80921189769131f593
+            repository: ghcr.io/alphagov/paas/curl-ssl
+            tag: 469ceea7a619b0abdd6cb27efd4d3bd5e9be3ddb
       run:
         path: sh
         args:


### PR DESCRIPTION
The switch is being made as we are consistency running into rate limiting issues with using the Docker Hub container repository. 

We already release 'curl-ssl' to GHCR so let's use that one instead. 