### PR TITLE
BAU: Remove trigger on image repo

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -39,7 +39,6 @@ jobs:
   - get: nightly
     trigger: true
   - get: gdpr-repository
-    trigger: true
     passed: [build-zendesk-GDPR-cleaner]
   - task: run
     image: gdpr-repository


### PR DESCRIPTION
This will prevent the job being run at the wrong time of day, which could interfear with people that use Zendesk and mess up the order of the tickets.