### PR TITLE
Make script output toggleable.

### DIFF
--- a/lib/tickets-autom8-able.rb
+++ b/lib/tickets-autom8-able.rb
@@ -9,6 +9,8 @@ directory_name = "#{directory}-#{today}"
 
 Dir.mkdir(directory_name) unless File.exists?(directory_name)
 
+output_to_console = ENV.fetch('OUTPUT_TO_CONSOLE', 'false').to_s.downcase == "true" 
+
 # get groups, so we are future proof
 groups_list = @client.groups
 
@@ -18,8 +20,10 @@ groups_list.each do |group|
   ticket_count_for_period = 0
 
   ticket_count_for_period = @client.search(:query => "type:ticket group:#{group_id} organization:none status:closed updated>=2012-01-01 updated<#{lastyear}").count.to_i
-  puts "Deletable Tickets for Group: #{group_id} : #{ticket_count_for_period}"
-  
+  if output_to_console
+    puts "Deletable Tickets for Group: #{group_id} : #{ticket_count_for_period}"
+  end
+
   if ticket_count_for_period != 0
     # calcuate no. of pages @ 100 items/page
     number_of_pages = (ticket_count_for_period.to_f / 100).ceil + 1
@@ -48,7 +52,9 @@ File.open(log_file_name, "w") {|log_file|
   filenames.each do |file|
     File.open("#{directory_name}/#{file}").each do |ticket_id|
       message = "Deleting Ticket: #{ticket_id.gsub("\n", '')} from Group: #{file}"
-      puts message
+      if output_to_console
+        puts message
+      end
       log_file.puts message
       @client.tickets.destroy!(:id => ticket_id.to_i)
     end

--- a/lib/user-ids-autom8-able.rb
+++ b/lib/user-ids-autom8-able.rb
@@ -7,6 +7,8 @@ require_relative 'zendesk-setup.rb'
 lastyear = Date.today.next_day - 365
 source_user_file = "data/selected_user_ids_meeting_gdpr_params.json"
 
+output_to_console = ENV.fetch('OUTPUT_TO_CONSOLE', 'false').to_s.downcase == "true" 
+
 def hard_delete(user_id, url, log_file)
   message = "Hard deleting user_id: #{user_id}"
   puts message
@@ -15,12 +17,16 @@ def hard_delete(user_id, url, log_file)
   begin
     # api does not support hard delete yet, so hard delete like this...
     full_url = "#{url}#{user_id}.json"
-    puts "full_url: #{full_url}"
+    if output_to_console
+      puts "full_url: #{full_url}"
+    end
     RestClient::Request.execute(method: :delete, url: full_url, user: ENV['ZENDESK_USER_EMAIL']+'/token', password: ENV['ZENDESK_TOKEN'])
 
   rescue RestClient::Exception => api_error
     message = "Received error from ZenDesk API Skipping over user #{user_id} => #{api_error}"
-    puts message
+    if output_to_console
+      puts message
+    end
     log_file.puts message
 
     return false
@@ -37,7 +43,9 @@ search_results = @client.search(:query => "type:user role:end-user -name:Zendesk
 user_count =  search_results.count
 number_of_pages = (user_count.to_f / 100).ceil
 
-puts "Retrieving #{user_count} user accounts, this may take a while"
+if output_to_console
+  puts "Retrieving #{user_count} user accounts, this may take a while"
+end
 
 File.open(source_user_file, "w") do |file|
 
@@ -70,7 +78,9 @@ File.open(log_file_name, "w") do |log_file|
     # then skip as we cannot delete them
     if user["shared_agent"]
       message = "user account #{user_id} cannot be deleted as it is marked as a 'shared_agent' from another zendesk account"
-      puts message
+      if output_to_console
+        puts message
+      end
       log_file.puts message
       next
     end
@@ -81,7 +91,9 @@ File.open(log_file_name, "w") do |log_file|
     # is user account already soft deleted, if so, hard delete
     if active.to_s == "false"
       message = "user account #{user_id} is already soft deleted"
-      puts message
+      if output_to_console
+        puts message
+      end
       log_file.puts message
       hard_delete(user_id, url, log_file)
       next
@@ -104,12 +116,16 @@ File.open(log_file_name, "w") do |log_file|
         ticket_count = Integer count
 
         message = "ticket_count: #{ticket_count}"
-        puts message
+        if output_to_console
+          puts message
+        end
         log_file.puts message
 
         if ticket_count == 0
           message = "Soft deleting user_id: #{user_id}"
-          puts message
+          if output_to_console
+            puts message
+          end
           log_file.puts message
 
           begin
@@ -117,19 +133,25 @@ File.open(log_file_name, "w") do |log_file|
 
           rescue ZendeskAPI::Error::RecordInvalid => api_error
             message = "Received error user #{user_id} already deleted, skipping over. Details: #{api_error.backtrace}"
-            puts message
+            if output_to_console
+              puts message
+            end
             log_file.puts message
             next
 
           rescue ZendeskAPI::Error::ReadTimeout => api_error
             message = "Received network error deleting user #{user_id}, skipping over. Details: #{api_error.backtrace}"
-            puts message
+            if output_to_console
+              puts message
+            end
             log_file.puts message
             next
 
           rescue ZendeskAPI::Error::NetworkError => api_error
             message = "Received network error, check user #{user_id}, skipping over. Details: #{api_error.backtrace}"
-            puts message
+            if output_to_console
+              puts message
+            end
             log_file.puts message
             raise
           end
@@ -138,7 +160,9 @@ File.open(log_file_name, "w") do |log_file|
 
         else
           message = "user_id: #{user_id} has #{ticket_count} tickets, not deleting"
-          puts message
+          if output_to_console
+            puts message
+          end
           log_file.puts message
 
         end


### PR DESCRIPTION
For upcoming migration to GHA, we no longer want the script to output to the console as it could be a GDPR violation as GHA logs are public.